### PR TITLE
Add AGENTS.md files for repo, Flutter app, and proxy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+Guidance for coding agents working in the Syncinary repository. This root file
+covers repo-wide layout and process; each subproject has its own `AGENTS.md`
+with the details that matter there. **The closest `AGENTS.md` to the file you
+are editing takes precedence.**
+
+## What this is
+
+Syncinary is a group travel-planning app (Purdue team project — Team 05: Ethan
+Bar, Prisha Boreddy, Jack Burky, Shubhi Agarwal). Two parts:
+
+- **`syncinary/`** — the Flutter app (Dart, Firebase Auth + Cloud Firestore).
+  Everything users see: auth, groups, itinerary, flight search.
+- **`proxy/`** — a small Node/Express service. Its only job today is to proxy
+  Google Flights requests to SerpApi so the SerpApi key stays off the client.
+
+`syncinary/lib/pages/amadeus_service.dart` calls the proxy at a hardcoded
+`http://localhost:3000`; the proxy must be running locally for flight search to
+work.
+
+## Repository layout
+
+| Path | What |
+|------|------|
+| `syncinary/` | Flutter app — see `syncinary/AGENTS.md` |
+| `proxy/` | Express/SerpApi proxy — see `proxy/AGENTS.md` |
+| `Doc/` | Course deliverables (`DevProcesses.md`, `Final SDP.md`, Design Document PDF). Not engineering docs — don't edit them to record implementation notes, and don't auto-generate summary files here. |
+| `.github/workflows/flutter_tests.yml` | CI (see below) |
+
+Which file to read next: editing `.dart` → `syncinary/AGENTS.md`; editing
+`proxy/*.js` → `proxy/AGENTS.md`.
+
+## Branching & pull requests
+
+Full policy is in `Doc/DevProcesses.md`. Essentials:
+
+- **`main` is locked** — never commit to it directly. One branch per feature.
+- Documented branch convention is `MAINFEATURE_SUBFEATURE` (e.g. `auth_login`).
+  Recent issue-driven work also uses `work-issue-<n>-<slug>`.
+- A PR needs both before it can merge: (1) review by a teammate who did not
+  write the branch, with every review comment addressed; (2) green CI.
+- PR title: short summary of the change. Description: the details, with
+  `Closes #<id>` at the bottom.
+
+## CI
+
+`.github/workflows/flutter_tests.yml` runs `flutter pub get` + `flutter test`
+in `syncinary/` on Flutter 3.47.2 (stable) — for every push on any branch and
+every PR to `main`. It does **not** run `flutter analyze` and does **not**
+touch `proxy/`; run those checks yourself before pushing.

--- a/proxy/AGENTS.md
+++ b/proxy/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md — flight proxy
+
+A ~30-line Express service. It exists so the SerpApi key isn't shipped inside
+the Flutter app. One route: `GET /flights` → SerpApi Google Flights, returning
+the `best_flights` / `other_flights` array as JSON. Run commands from this
+directory (`proxy/`).
+
+## Setup / run
+
+```bash
+npm install          # rarely needed — see below
+node server.js       # listens on http://localhost:3000
+```
+
+Node 18+ (CommonJS, `require`). Dependencies: `express`, `cors`, and
+`node-fetch@2` — v2 is deliberate, it's the last CommonJS release of the
+package.
+
+`node_modules/` is **committed** (~650 files) on purpose: there's no build step
+and CI doesn't install here. Adding a dependency means committing it too, so
+add one only if you genuinely need it.
+
+## Test
+
+There is no test suite and no `test` script yet. If you add logic worth
+testing, use Node's built-in runner: files named `*.test.js` beside the module,
+`node --test` to run them, and add `"scripts": { "test": "node --test" }` to
+`package.json` so CI can pick it up later.
+
+## Conventions
+
+- Keep it CommonJS and dependency-light.
+- The Flutter client calls
+  `GET /flights?origin=&destination=&departureDate=&adults=` and expects a JSON
+  array back. Don't change that contract without updating
+  `syncinary/lib/pages/amadeus_service.dart` in the same change.
+
+## Security
+
+- **Known issue:** `server.js` contains a hardcoded live `SERPAPI_KEY`. Don't
+  copy that pattern and don't add more secrets to source — read them from
+  `process.env` (e.g. `node --env-file=.env server.js`, Node 20.6+). Moving the
+  existing key to an env var and rotating it is its own task.
+- Never forward the SerpApi key to the client, and don't log full upstream
+  responses that may carry it.

--- a/syncinary/AGENTS.md
+++ b/syncinary/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md — Flutter app
+
+The Syncinary client. Flutter / Dart, Firebase Auth + Cloud Firestore. Run
+commands from this directory (`syncinary/`).
+
+## Setup
+
+```bash
+flutter pub get
+```
+
+`lib/firebase_options.dart` is **gitignored** (it holds Firebase API keys) and
+is absent from a fresh clone. Until it exists, `flutter analyze` and
+`flutter run` fail with `Target of URI doesn't exist: 'firebase_options.dart'`.
+Regenerate it with the FlutterFire CLI against project `syncinary-48881`:
+
+```bash
+flutterfire configure --project=syncinary-48881
+```
+
+`flutter test` does **not** need this file — the test suite doesn't import
+`main.dart`.
+
+## Build / run
+
+- `flutter run` — needs `firebase_options.dart` (see Setup)
+- `flutter build <apk|web|windows|…>`
+
+The platform folders (`android/ ios/ web/ windows/ macos/ linux/`) and `build/`
+are generated. Don't hand-edit them without a specific reason.
+
+## Test
+
+```bash
+flutter test
+```
+
+Baseline on `main`: **9 passing, 0 failing.** Tests live in `test/`, one file
+per feature (`login_page_test.dart`, `groups_flow_test.dart`). Firestore/Auth
+code is tested with `fake_cloud_firestore` + `firebase_auth_mocks` — no
+emulator, no network. Add tests next to their peers and keep them offline.
+
+## Analyze / lint
+
+```bash
+flutter analyze
+```
+
+Config: `analysis_options.yaml` pulls in `package:flutter_lints/flutter.yaml`
+with no custom rules; platform dirs and `build/` are excluded. Pre-existing
+baseline — do **not** fix these as a drive-by:
+
+- 2 errors from the missing `lib/firebase_options.dart` (see Setup)
+- info-level `camel_case_types` on `flight_search`, `itinerary_builder`,
+  `_itineraryState`, and one `unnecessary_underscores` in `theme/app_theme.dart`
+
+**New code must not add issues.** CI does not run analyze, so run it yourself
+before pushing.
+
+## Layout
+
+```
+lib/
+  main.dart              # entry; Firebase.initializeApp + AuthGate (routes on auth state)
+  models/                # data classes + Firestore (de)serialization  — group.dart
+  pages/                 # one screen per file
+    groups/              # the Group feature's screens and dialogs
+  services/              # Firestore/Auth data access — group_service.dart
+  widgets/               # shared widgets (dialogs, app bar, overlays)
+  theme/app_theme.dart   # design system: AppColors, AppTextStyles, buildAppTheme()
+```
+
+New screens go in `lib/pages/` (feature subfolder if it has several); new data
+access goes in `lib/services/`; each source file's test mirrors its path under
+`test/`.
+
+## Conventions
+
+- **Style:** follow `flutter_lints` — `UpperCamelCase` types, `const`
+  constructors, `super.key`. Some existing widget classes are `snake_case`
+  (`itinerary_builder`); that's legacy. Match the lint, not the neighbour.
+- **Data access goes through a class, not a widget.** UI does not call
+  Firestore or `http` directly — it uses a class in `lib/services/` (Firestore)
+  or a service like `AmadeusService` (proxy). See `GroupService`.
+- **Constructor-inject `FirebaseFirestore` / `FirebaseAuth`** as nullable
+  params that default to `.instance`, so tests can pass fakes. `GroupService`,
+  `LoginPage`, and `SignUpPage` all follow this.
+- **Firestore collections:** `users/{uid}` (`{ email, username, createdAt }`),
+  `groups/{groupId}`, `invites`, `inviteCodes` (maps `inviteCode -> groupId`).
+- Flight calls target the proxy at `http://localhost:3000`, hardcoded in
+  `AmadeusService`.


### PR DESCRIPTION
Closes #72

## What
Adds AGENTS.md guidance for coding agents, following the conventions at
https://agents.md/. Nested layout: a thin root file plus one per subproject,
since `syncinary/` (Flutter) and `proxy/` (Node) share no tooling and the
closest file wins.

## Changes
- `AGENTS.md` — repo layout, which subproject file to read next, branch/PR
  policy (from `Doc/DevProcesses.md`), and what CI runs.
- `syncinary/AGENTS.md` — setup (incl. the gitignored `firebase_options.dart`
  that a fresh clone must regenerate), build/run, `flutter test` (9 passing
  baseline), `flutter analyze` with its pre-existing lint baseline, `lib/`
  layout, and conventions (service-class data access, constructor-injected
  Firebase, Firestore collections).
- `proxy/AGENTS.md` — setup/run, committed `node_modules/`, the missing test
  setup, the request contract shared with `AmadeusService`, and the hardcoded
  `SERPAPI_KEY` flagged as a known issue.

Docs only — no source, config, or CI changes.

## Testing
`flutter test` in `syncinary/` — 9 passing, 0 failing (unchanged).