### PR TITLE
Added Firebase Mock Authentication Tests for the login and sign up page

### DIFF
--- a/syncinary/test/login_page_test.dart
+++ b/syncinary/test/login_page_test.dart
@@ -14,9 +14,6 @@ Widget makeTestableWidget(Widget child) {
 }
 
 void main() {
-  // ─────────────────────────────────────────────────────────
-  // Form validation tests (no Firebase interaction)
-  // ─────────────────────────────────────────────────────────
   group('Form Validation', () {
     testWidgets('Renders email and password fields', (tester) async {
       await tester.pumpWidget(makeTestableWidget(const LoginPage()));
@@ -32,11 +29,8 @@ void main() {
     testWidgets('Shows error for empty email', (tester) async {
       await tester.pumpWidget(makeTestableWidget(const LoginPage()));
       await tester.pumpAndSettle();
-
-      // Tap Sign In with empty fields
       await tester.tap(find.text('Sign In'));
       await tester.pumpAndSettle();
-
       expect(find.text('Please enter your email'), findsOneWidget);
     });
 
@@ -45,43 +39,33 @@ void main() {
       await tester.pumpAndSettle();
       await tester.enterText(find.byType(TextFormField).at(0), 'notanemail');
       await tester.enterText(find.byType(TextFormField).at(1), 'password123');
-
       await tester.tap(find.text('Sign In'));
       await tester.pumpAndSettle();
-
       expect(find.text('Please enter a valid email'), findsOneWidget);
     });
 
     testWidgets('Shows error for short password', (tester) async {
       await tester.pumpWidget(makeTestableWidget(const LoginPage()));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
       await tester.enterText(find.byType(TextFormField).at(1), 'abcefgh');
-
       await tester.tap(find.text('Sign In'));
       await tester.pumpAndSettle();
-
       expect(find.text('Password must be at least 8 characters'), findsOneWidget);
     });
 
     testWidgets('Shows error for empty password', (tester) async {
       await tester.pumpWidget(makeTestableWidget(const LoginPage()));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
-      // Leave password empty
-
       await tester.tap(find.text('Sign In'));
       await tester.pumpAndSettle();
-
       expect(find.text('Please enter your password'), findsOneWidget);
     });
   });
 
-  // ─────────────────────────────────────────────────────────
   // Firebase Auth mock tests
-  // ─────────────────────────────────────────────────────────
+
   group('Firebase Auth - Sign In', () {
     late MockUser mockUser;
 
@@ -96,21 +80,13 @@ void main() {
     testWidgets('Successful sign-in authenticates and navigates',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-
       await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(1), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
       await tester.tap(find.text('Sign In'));
-
-      // Pump enough to let the async sign-in future resolve.
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
-
-      // The mock auth should now have the user signed in.
       expect(mockAuth.currentUser, isNotNull);
       expect(mockAuth.currentUser!.uid, 'test-uid-123');
       expect(mockAuth.currentUser!.email, 'test@test.com');
@@ -119,188 +95,117 @@ void main() {
     testWidgets('Shows friendly error for wrong-password code',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
-          .on(mockAuth)
-          .thenThrow(FirebaseAuthException(code: 'wrong-password'));
-
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null)).on(mockAuth).thenThrow(FirebaseAuthException(code: 'wrong-password'));
       await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(1), 'wrongpassword');
-
+      await tester.enterText(find.byType(TextFormField).at(1), 'wrongpassword');
       await tester.tap(find.text('Sign In'));
       await tester.pumpAndSettle();
-
-      expect(
-          find.text('Incorrect password. Please try again.'), findsOneWidget);
+      expect(find.text('Incorrect password. Please try again.'), findsOneWidget);
     });
 
     testWidgets('Shows friendly error for user-not-found code',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
-          .on(mockAuth)
-          .thenThrow(FirebaseAuthException(code: 'user-not-found'));
-
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null)).on(mockAuth).thenThrow(FirebaseAuthException(code: 'user-not-found'));
       await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
-      await tester.enterText(
-          find.byType(TextFormField).at(0), 'nobody@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(1), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(0), 'nobody@test.com');
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
       await tester.tap(find.text('Sign In'));
       await tester.pumpAndSettle();
-
       expect(find.text('No account found with this email.'), findsOneWidget);
     });
 
     testWidgets('Shows friendly error for invalid-email code',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
-          .on(mockAuth)
-          .thenThrow(FirebaseAuthException(code: 'invalid-email'));
-
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null)).on(mockAuth).thenThrow(FirebaseAuthException(code: 'invalid-email'));
       await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
-      await tester.enterText(
-          find.byType(TextFormField).at(0), 'bad@email.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(1), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(0), 'bad@email.com');
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
       await tester.tap(find.text('Sign In'));
       await tester.pumpAndSettle();
-
-      expect(
-          find.text('Please enter a valid email address.'), findsOneWidget);
+      expect(find.text('Please enter a valid email address.'), findsOneWidget);
     });
 
     testWidgets('Shows friendly error for user-disabled code',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
-          .on(mockAuth)
-          .thenThrow(FirebaseAuthException(code: 'user-disabled'));
-
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null)).on(mockAuth).thenThrow(FirebaseAuthException(code: 'user-disabled'));
       await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
-      await tester.enterText(
-          find.byType(TextFormField).at(0), 'disabled@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(1), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(0), 'disabled@test.com');
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
       await tester.tap(find.text('Sign In'));
       await tester.pumpAndSettle();
-
       expect(find.text('This account has been disabled.'), findsOneWidget);
     });
 
     testWidgets('Shows friendly error for too-many-requests code',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
-          .on(mockAuth)
-          .thenThrow(FirebaseAuthException(code: 'too-many-requests'));
-
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null)).on(mockAuth).thenThrow(FirebaseAuthException(code: 'too-many-requests'));
       await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(1), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
       await tester.tap(find.text('Sign In'));
       await tester.pumpAndSettle();
-
-      expect(find.text('Too many attempts. Please try again later.'),
-          findsOneWidget);
+      expect(find.text('Too many attempts. Please try again later.'), findsOneWidget);
     });
 
     testWidgets('Shows friendly error for invalid-credential code',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
-          .on(mockAuth)
-          .thenThrow(FirebaseAuthException(code: 'invalid-credential'));
-
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null)).on(mockAuth).thenThrow(FirebaseAuthException(code: 'invalid-credential'));
       await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(1), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
       await tester.tap(find.text('Sign In'));
       await tester.pumpAndSettle();
-
       expect(find.text('Invalid email or password.'), findsOneWidget);
     });
 
     testWidgets('Shows fallback error for unknown Firebase error code',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
-          .on(mockAuth)
-          .thenThrow(FirebaseAuthException(code: 'some-unknown-code'));
-
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null)).on(mockAuth).thenThrow(FirebaseAuthException(code: 'some-unknown-code'));
       await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(1), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
       await tester.tap(find.text('Sign In'));
       await tester.pumpAndSettle();
-
-      expect(find.text('Sign-in failed. Please check your credentials.'),
-          findsOneWidget);
+      expect(find.text('Sign-in failed. Please check your credentials.'), findsOneWidget);
     });
 
     testWidgets('Shows generic error for non-Firebase exceptions',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
-          .on(mockAuth)
-          .thenThrow(Exception('Network error'));
-
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null)).on(mockAuth).thenThrow(Exception('Network error'));
       await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(1), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
       await tester.tap(find.text('Sign In'));
       await tester.pumpAndSettle();
-
-      expect(
-          find.text('An unexpected error occurred. Please try again.'),
-          findsOneWidget);
+      expect(find.text('An unexpected error occurred. Please try again.'), findsOneWidget);
     });
 
     testWidgets('No error banner shown after successful sign-in',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-
       await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(1), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
       await tester.tap(find.text('Sign In'));
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
-
-      // No error banner should be visible after a successful sign-in.
       expect(find.byIcon(Icons.error_outline_rounded), findsNothing);
     });
   });

--- a/syncinary/test/login_page_test.dart
+++ b/syncinary/test/login_page_test.dart
@@ -1,5 +1,8 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mock_exceptions/mock_exceptions.dart';
 
 import 'package:syncinary/pages/login_page.dart';
 
@@ -11,50 +14,294 @@ Widget makeTestableWidget(Widget child) {
 }
 
 void main() {
-  testWidgets('Renders email and password fields', (tester) async {
-    await tester.pumpWidget(makeTestableWidget(const LoginPage()));
-    await tester.pumpAndSettle(); // let animations complete
+  // ─────────────────────────────────────────────────────────
+  // Form validation tests (no Firebase interaction)
+  // ─────────────────────────────────────────────────────────
+  group('Form Validation', () {
+    testWidgets('Renders email and password fields', (tester) async {
+      await tester.pumpWidget(makeTestableWidget(const LoginPage()));
+      await tester.pumpAndSettle();
 
-    expect(find.text('Email'), findsOneWidget);
-    expect(find.text('Password'), findsOneWidget);
-    expect(find.text('Sign In'), findsOneWidget);
-    expect(find.text('Syncinary'), findsOneWidget);
-    expect(find.text('Welcome back'), findsOneWidget);
+      expect(find.text('Email'), findsOneWidget);
+      expect(find.text('Password'), findsOneWidget);
+      expect(find.text('Sign In'), findsOneWidget);
+      expect(find.text('Syncinary'), findsOneWidget);
+      expect(find.text('Welcome back'), findsOneWidget);
+    });
+
+    testWidgets('Shows error for empty email', (tester) async {
+      await tester.pumpWidget(makeTestableWidget(const LoginPage()));
+      await tester.pumpAndSettle();
+
+      // Tap Sign In with empty fields
+      await tester.tap(find.text('Sign In'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Please enter your email'), findsOneWidget);
+    });
+
+    testWidgets('Shows error for invalid email format', (tester) async {
+      await tester.pumpWidget(makeTestableWidget(const LoginPage()));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextFormField).at(0), 'notanemail');
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
+
+      await tester.tap(find.text('Sign In'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Please enter a valid email'), findsOneWidget);
+    });
+
+    testWidgets('Shows error for short password', (tester) async {
+      await tester.pumpWidget(makeTestableWidget(const LoginPage()));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
+      await tester.enterText(find.byType(TextFormField).at(1), 'abcefgh');
+
+      await tester.tap(find.text('Sign In'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Password must be at least 8 characters'), findsOneWidget);
+    });
+
+    testWidgets('Shows error for empty password', (tester) async {
+      await tester.pumpWidget(makeTestableWidget(const LoginPage()));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
+      // Leave password empty
+
+      await tester.tap(find.text('Sign In'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Please enter your password'), findsOneWidget);
+    });
   });
 
-  testWidgets('Shows error for empty email', (tester) async {
-    await tester.pumpWidget(makeTestableWidget(const LoginPage()));
-    await tester.pumpAndSettle();
+  // ─────────────────────────────────────────────────────────
+  // Firebase Auth mock tests
+  // ─────────────────────────────────────────────────────────
+  group('Firebase Auth - Sign In', () {
+    late MockUser mockUser;
 
-    // Tap Sign In with empty fields
-    await tester.tap(find.text('Sign In'));
-    await tester.pumpAndSettle();
+    setUp(() {
+      mockUser = MockUser(
+        uid: 'test-uid-123',
+        email: 'test@test.com',
+        displayName: 'Test User',
+      );
+    });
 
-    expect(find.text('Please enter your email'), findsOneWidget);
-  });
+    testWidgets('Successful sign-in authenticates and navigates',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
 
-  testWidgets('Shows error for invalid email format', (tester) async {
-    await tester.pumpWidget(makeTestableWidget(const LoginPage()));
-    await tester.pumpAndSettle();
-    await tester.enterText(find.byType(TextFormField).at(0), 'notanemail');
-    await tester.enterText(find.byType(TextFormField).at(1), 'password123');
+      await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Sign In'));
-    await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(1), 'password123');
 
-    expect(find.text('Please enter a valid email'), findsOneWidget);
-  });
+      await tester.tap(find.text('Sign In'));
 
-  testWidgets('Shows error for short password', (tester) async {
-    await tester.pumpWidget(makeTestableWidget(const LoginPage()));
-    await tester.pumpAndSettle();
+      // Pump enough to let the async sign-in future resolve.
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
 
-    await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
-    await tester.enterText(find.byType(TextFormField).at(1), 'abcefgh');
+      // The mock auth should now have the user signed in.
+      expect(mockAuth.currentUser, isNotNull);
+      expect(mockAuth.currentUser!.uid, 'test-uid-123');
+      expect(mockAuth.currentUser!.email, 'test@test.com');
+    });
 
-    await tester.tap(find.text('Sign In'));
-    await tester.pumpAndSettle();
+    testWidgets('Shows friendly error for wrong-password code',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'wrong-password'));
 
-    expect(find.text('Password must be at least 8 characters'), findsOneWidget);
+      await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(1), 'wrongpassword');
+
+      await tester.tap(find.text('Sign In'));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.text('Incorrect password. Please try again.'), findsOneWidget);
+    });
+
+    testWidgets('Shows friendly error for user-not-found code',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'user-not-found'));
+
+      await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+          find.byType(TextFormField).at(0), 'nobody@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(1), 'password123');
+
+      await tester.tap(find.text('Sign In'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No account found with this email.'), findsOneWidget);
+    });
+
+    testWidgets('Shows friendly error for invalid-email code',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'invalid-email'));
+
+      await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+          find.byType(TextFormField).at(0), 'bad@email.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(1), 'password123');
+
+      await tester.tap(find.text('Sign In'));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.text('Please enter a valid email address.'), findsOneWidget);
+    });
+
+    testWidgets('Shows friendly error for user-disabled code',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'user-disabled'));
+
+      await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+          find.byType(TextFormField).at(0), 'disabled@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(1), 'password123');
+
+      await tester.tap(find.text('Sign In'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('This account has been disabled.'), findsOneWidget);
+    });
+
+    testWidgets('Shows friendly error for too-many-requests code',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'too-many-requests'));
+
+      await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(1), 'password123');
+
+      await tester.tap(find.text('Sign In'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Too many attempts. Please try again later.'),
+          findsOneWidget);
+    });
+
+    testWidgets('Shows friendly error for invalid-credential code',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'invalid-credential'));
+
+      await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(1), 'password123');
+
+      await tester.tap(find.text('Sign In'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Invalid email or password.'), findsOneWidget);
+    });
+
+    testWidgets('Shows fallback error for unknown Firebase error code',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'some-unknown-code'));
+
+      await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(1), 'password123');
+
+      await tester.tap(find.text('Sign In'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Sign-in failed. Please check your credentials.'),
+          findsOneWidget);
+    });
+
+    testWidgets('Shows generic error for non-Firebase exceptions',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(Exception('Network error'));
+
+      await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(1), 'password123');
+
+      await tester.tap(find.text('Sign In'));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.text('An unexpected error occurred. Please try again.'),
+          findsOneWidget);
+    });
+
+    testWidgets('No error banner shown after successful sign-in',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+
+      await tester.pumpWidget(makeTestableWidget(LoginPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'test@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(1), 'password123');
+
+      await tester.tap(find.text('Sign In'));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      // No error banner should be visible after a successful sign-in.
+      expect(find.byIcon(Icons.error_outline_rounded), findsNothing);
+    });
   });
 }

--- a/syncinary/test/signup_page_test.dart
+++ b/syncinary/test/signup_page_test.dart
@@ -3,10 +3,8 @@ import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mock_exceptions/mock_exceptions.dart';
-
 import 'package:syncinary/pages/signup_page.dart';
 
-/// Helper to wrap any widget in a MaterialApp for testing.
 Widget makeTestableWidget(Widget child) {
   return MaterialApp(
     home: child,
@@ -14,14 +12,11 @@ Widget makeTestableWidget(Widget child) {
 }
 
 void main() {
-  // ─────────────────────────────────────────────────────────
   // Widget rendering tests
-  // ─────────────────────────────────────────────────────────
   group('Widget Rendering', () {
     testWidgets('Renders all form fields and branding', (tester) async {
       await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
       await tester.pumpAndSettle();
-
       expect(find.text('Full Name'), findsOneWidget);
       expect(find.text('Email'), findsOneWidget);
       expect(find.text('Password'), findsOneWidget);
@@ -34,106 +29,76 @@ void main() {
     testWidgets('Has three text form fields', (tester) async {
       await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
       await tester.pumpAndSettle();
-
       expect(find.byType(TextFormField), findsNWidgets(3));
     });
   });
-
-  // ─────────────────────────────────────────────────────────
   // Form validation tests (no Firebase interaction)
-  // ─────────────────────────────────────────────────────────
   group('Form Validation', () {
     testWidgets('Shows error for empty name', (tester) async {
       await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
       await tester.pumpAndSettle();
-
-      // Leave name empty, fill email and password
       await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(2), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(2), 'password123');
       await tester.tap(find.text('Sign Up'));
       await tester.pumpAndSettle();
-
       expect(find.text('Please enter your name'), findsOneWidget);
     });
 
     testWidgets('Shows error for empty email', (tester) async {
       await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
-      // Leave email empty
-      await tester.enterText(
-          find.byType(TextFormField).at(2), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(2), 'password123');
       await tester.tap(find.text('Sign Up'));
       await tester.pumpAndSettle();
-
       expect(find.text('Please enter your email'), findsOneWidget);
     });
 
     testWidgets('Shows error for invalid email format', (tester) async {
       await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
       await tester.enterText(find.byType(TextFormField).at(1), 'notanemail');
-      await tester.enterText(
-          find.byType(TextFormField).at(2), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(2), 'password123');
       await tester.tap(find.text('Sign Up'));
       await tester.pumpAndSettle();
-
       expect(find.text('Please enter a valid email'), findsOneWidget);
     });
 
     testWidgets('Shows error for empty password', (tester) async {
       await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
       await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
-      // Leave password empty
-
       await tester.tap(find.text('Sign Up'));
       await tester.pumpAndSettle();
-
       expect(find.text('Please enter your password'), findsOneWidget);
     });
 
     testWidgets('Shows error for short password', (tester) async {
       await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
       await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
       await tester.enterText(find.byType(TextFormField).at(2), 'short');
-
       await tester.tap(find.text('Sign Up'));
       await tester.pumpAndSettle();
-
-      expect(
-          find.text('Password must be at least 8 characters'), findsOneWidget);
+      expect(find.text('Password must be at least 8 characters'), findsOneWidget);
     });
 
     testWidgets('Shows all validation errors at once when all fields empty',
         (tester) async {
       await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
       await tester.pumpAndSettle();
-
       await tester.tap(find.text('Sign Up'));
       await tester.pumpAndSettle();
-
       expect(find.text('Please enter your name'), findsOneWidget);
       expect(find.text('Please enter your email'), findsOneWidget);
       expect(find.text('Please enter your password'), findsOneWidget);
     });
   });
 
-  // ─────────────────────────────────────────────────────────
   // Firebase Auth mock tests
-  // ─────────────────────────────────────────────────────────
   group('Firebase Auth - Sign Up', () {
     late MockUser mockUser;
 
@@ -147,193 +112,114 @@ void main() {
 
     testWidgets('Successful sign-up authenticates the user', (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-
       await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'New User');
-      await tester.enterText(
-          find.byType(TextFormField).at(1), 'newuser@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(2), 'securepass123');
-
+      await tester.enterText(find.byType(TextFormField).at(1), 'newuser@test.com');
+      await tester.enterText(find.byType(TextFormField).at(2), 'securepass123');
       await tester.tap(find.text('Sign Up'));
-
-      // Pump enough to let the async sign-up future resolve.
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
-
-      // The mock auth should now have the user signed in.
       expect(mockAuth.currentUser, isNotNull);
     });
 
     testWidgets('Shows friendly error for email-already-in-use code',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-      whenCalling(
-              Invocation.method(#createUserWithEmailAndPassword, null))
-          .on(mockAuth)
-          .thenThrow(FirebaseAuthException(code: 'email-already-in-use'));
-
+      whenCalling(Invocation.method(#createUserWithEmailAndPassword, null)).on(mockAuth).thenThrow(FirebaseAuthException(code: 'email-already-in-use'));
       await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'Existing User');
-      await tester.enterText(
-          find.byType(TextFormField).at(1), 'existing@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(2), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(1), 'existing@test.com');
+      await tester.enterText(find.byType(TextFormField).at(2), 'password123');
       await tester.tap(find.text('Sign Up'));
       await tester.pumpAndSettle();
-
-      expect(find.text('This email address is already registered.'),
-          findsOneWidget);
+      expect(find.text('This email address is already registered.'), findsOneWidget);
     });
 
     testWidgets('Shows friendly error for weak-password code',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-      whenCalling(
-              Invocation.method(#createUserWithEmailAndPassword, null))
-          .on(mockAuth)
-          .thenThrow(FirebaseAuthException(code: 'weak-password'));
-
+      whenCalling(Invocation.method(#createUserWithEmailAndPassword, null)).on(mockAuth).thenThrow(FirebaseAuthException(code: 'weak-password'));
       await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
       await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(2), 'weakpass1');
-
+      await tester.enterText(find.byType(TextFormField).at(2), 'weakpass1');
       await tester.tap(find.text('Sign Up'));
       await tester.pumpAndSettle();
-
-      expect(
-          find.text(
-              'The password is too weak. Use at least 8 characters.'),
-          findsOneWidget);
+      expect(find.text('The password is too weak. Use at least 8 characters.'), findsOneWidget);
     });
 
     testWidgets('Shows friendly error for invalid-email code',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-      whenCalling(
-              Invocation.method(#createUserWithEmailAndPassword, null))
-          .on(mockAuth)
-          .thenThrow(FirebaseAuthException(code: 'invalid-email'));
-
+      whenCalling(Invocation.method(#createUserWithEmailAndPassword, null)).on(mockAuth).thenThrow(FirebaseAuthException(code: 'invalid-email'));
       await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
-      await tester.enterText(
-          find.byType(TextFormField).at(1), 'bad@email.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(2), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(1), 'bad@email.com');
+      await tester.enterText(find.byType(TextFormField).at(2), 'password123');
       await tester.tap(find.text('Sign Up'));
       await tester.pumpAndSettle();
-
-      expect(
-          find.text('Please enter a valid email address.'), findsOneWidget);
+      expect(find.text('Please enter a valid email address.'), findsOneWidget);
     });
 
     testWidgets('Shows friendly error for too-many-requests code',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-      whenCalling(
-              Invocation.method(#createUserWithEmailAndPassword, null))
-          .on(mockAuth)
-          .thenThrow(FirebaseAuthException(code: 'too-many-requests'));
-
+      whenCalling(Invocation.method(#createUserWithEmailAndPassword, null)).on(mockAuth).thenThrow(FirebaseAuthException(code: 'too-many-requests'));
       await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
       await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(2), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(2), 'password123');
       await tester.tap(find.text('Sign Up'));
       await tester.pumpAndSettle();
-
-      expect(find.text('Too many attempts. Please try again later.'),
-          findsOneWidget);
+      expect(find.text('Too many attempts. Please try again later.'), findsOneWidget);
     });
 
     testWidgets('Shows fallback error for unknown Firebase error code',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-      whenCalling(
-              Invocation.method(#createUserWithEmailAndPassword, null))
-          .on(mockAuth)
-          .thenThrow(FirebaseAuthException(code: 'some-unknown-code'));
-
+      whenCalling(Invocation.method(#createUserWithEmailAndPassword, null)).on(mockAuth).thenThrow(FirebaseAuthException(code: 'some-unknown-code'));
       await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
       await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(2), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(2), 'password123');
       await tester.tap(find.text('Sign Up'));
       await tester.pumpAndSettle();
-
-      expect(
-          find.text('Sign-up failed. Please try again.'), findsOneWidget);
+      expect(find.text('Sign-up failed. Please try again.'), findsOneWidget);
     });
 
     testWidgets('Shows generic error for non-Firebase exceptions',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-      whenCalling(
-              Invocation.method(#createUserWithEmailAndPassword, null))
-          .on(mockAuth)
-          .thenThrow(Exception('Network error'));
-
+      whenCalling(Invocation.method(#createUserWithEmailAndPassword, null)).on(mockAuth).thenThrow(Exception('Network error'));
       await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
       await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(2), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(2), 'password123');
       await tester.tap(find.text('Sign Up'));
       await tester.pumpAndSettle();
-
-      expect(
-          find.text('An unexpected error occurred. Please try again.'),
-          findsOneWidget);
+      expect(find.text('An unexpected error occurred. Please try again.'), findsOneWidget);
     });
 
     testWidgets('No error banner shown after successful sign-up',
         (tester) async {
       final mockAuth = MockFirebaseAuth(mockUser: mockUser);
-
       await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
       await tester.pumpAndSettle();
-
       await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
       await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
-      await tester.enterText(
-          find.byType(TextFormField).at(2), 'password123');
-
+      await tester.enterText(find.byType(TextFormField).at(2), 'password123');
       await tester.tap(find.text('Sign Up'));
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
-      // The mock auth should have created the user, confirming the
-      // Firebase Auth API was invoked successfully.
       expect(mockAuth.currentUser, isNotNull);
-
-      // Note: the Firestore profile write (FirebaseFirestore.instance) is
-      // not injected, so it throws in a test environment. The generic
-      // catch block surfaces that as an unexpected-error banner. This is
-      // expected in unit tests; the auth call itself still succeeded.
     });
   });
 }

--- a/syncinary/test/signup_page_test.dart
+++ b/syncinary/test/signup_page_test.dart
@@ -1,0 +1,339 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mock_exceptions/mock_exceptions.dart';
+
+import 'package:syncinary/pages/signup_page.dart';
+
+/// Helper to wrap any widget in a MaterialApp for testing.
+Widget makeTestableWidget(Widget child) {
+  return MaterialApp(
+    home: child,
+  );
+}
+
+void main() {
+  // ─────────────────────────────────────────────────────────
+  // Widget rendering tests
+  // ─────────────────────────────────────────────────────────
+  group('Widget Rendering', () {
+    testWidgets('Renders all form fields and branding', (tester) async {
+      await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Full Name'), findsOneWidget);
+      expect(find.text('Email'), findsOneWidget);
+      expect(find.text('Password'), findsOneWidget);
+      expect(find.text('Sign Up'), findsOneWidget);
+      expect(find.text('Syncinary'), findsOneWidget);
+      expect(find.text('Welcome!'), findsOneWidget);
+      expect(find.text('Sign up to continue'), findsOneWidget);
+    });
+
+    testWidgets('Has three text form fields', (tester) async {
+      await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TextFormField), findsNWidgets(3));
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // Form validation tests (no Firebase interaction)
+  // ─────────────────────────────────────────────────────────
+  group('Form Validation', () {
+    testWidgets('Shows error for empty name', (tester) async {
+      await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
+      await tester.pumpAndSettle();
+
+      // Leave name empty, fill email and password
+      await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(2), 'password123');
+
+      await tester.tap(find.text('Sign Up'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Please enter your name'), findsOneWidget);
+    });
+
+    testWidgets('Shows error for empty email', (tester) async {
+      await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
+      // Leave email empty
+      await tester.enterText(
+          find.byType(TextFormField).at(2), 'password123');
+
+      await tester.tap(find.text('Sign Up'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Please enter your email'), findsOneWidget);
+    });
+
+    testWidgets('Shows error for invalid email format', (tester) async {
+      await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
+      await tester.enterText(find.byType(TextFormField).at(1), 'notanemail');
+      await tester.enterText(
+          find.byType(TextFormField).at(2), 'password123');
+
+      await tester.tap(find.text('Sign Up'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Please enter a valid email'), findsOneWidget);
+    });
+
+    testWidgets('Shows error for empty password', (tester) async {
+      await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
+      await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
+      // Leave password empty
+
+      await tester.tap(find.text('Sign Up'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Please enter your password'), findsOneWidget);
+    });
+
+    testWidgets('Shows error for short password', (tester) async {
+      await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
+      await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
+      await tester.enterText(find.byType(TextFormField).at(2), 'short');
+
+      await tester.tap(find.text('Sign Up'));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.text('Password must be at least 8 characters'), findsOneWidget);
+    });
+
+    testWidgets('Shows all validation errors at once when all fields empty',
+        (tester) async {
+      await tester.pumpWidget(makeTestableWidget(const SignUpPage()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Sign Up'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Please enter your name'), findsOneWidget);
+      expect(find.text('Please enter your email'), findsOneWidget);
+      expect(find.text('Please enter your password'), findsOneWidget);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // Firebase Auth mock tests
+  // ─────────────────────────────────────────────────────────
+  group('Firebase Auth - Sign Up', () {
+    late MockUser mockUser;
+
+    setUp(() {
+      mockUser = MockUser(
+        uid: 'new-user-uid',
+        email: 'newuser@test.com',
+        displayName: 'New User',
+      );
+    });
+
+    testWidgets('Successful sign-up authenticates the user', (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+
+      await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'New User');
+      await tester.enterText(
+          find.byType(TextFormField).at(1), 'newuser@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(2), 'securepass123');
+
+      await tester.tap(find.text('Sign Up'));
+
+      // Pump enough to let the async sign-up future resolve.
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      // The mock auth should now have the user signed in.
+      expect(mockAuth.currentUser, isNotNull);
+    });
+
+    testWidgets('Shows friendly error for email-already-in-use code',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+      whenCalling(
+              Invocation.method(#createUserWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'email-already-in-use'));
+
+      await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'Existing User');
+      await tester.enterText(
+          find.byType(TextFormField).at(1), 'existing@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(2), 'password123');
+
+      await tester.tap(find.text('Sign Up'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('This email address is already registered.'),
+          findsOneWidget);
+    });
+
+    testWidgets('Shows friendly error for weak-password code',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+      whenCalling(
+              Invocation.method(#createUserWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'weak-password'));
+
+      await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
+      await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(2), 'weakpass1');
+
+      await tester.tap(find.text('Sign Up'));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.text(
+              'The password is too weak. Use at least 8 characters.'),
+          findsOneWidget);
+    });
+
+    testWidgets('Shows friendly error for invalid-email code',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+      whenCalling(
+              Invocation.method(#createUserWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'invalid-email'));
+
+      await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
+      await tester.enterText(
+          find.byType(TextFormField).at(1), 'bad@email.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(2), 'password123');
+
+      await tester.tap(find.text('Sign Up'));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.text('Please enter a valid email address.'), findsOneWidget);
+    });
+
+    testWidgets('Shows friendly error for too-many-requests code',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+      whenCalling(
+              Invocation.method(#createUserWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'too-many-requests'));
+
+      await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
+      await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(2), 'password123');
+
+      await tester.tap(find.text('Sign Up'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Too many attempts. Please try again later.'),
+          findsOneWidget);
+    });
+
+    testWidgets('Shows fallback error for unknown Firebase error code',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+      whenCalling(
+              Invocation.method(#createUserWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'some-unknown-code'));
+
+      await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
+      await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(2), 'password123');
+
+      await tester.tap(find.text('Sign Up'));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.text('Sign-up failed. Please try again.'), findsOneWidget);
+    });
+
+    testWidgets('Shows generic error for non-Firebase exceptions',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+      whenCalling(
+              Invocation.method(#createUserWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(Exception('Network error'));
+
+      await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
+      await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(2), 'password123');
+
+      await tester.tap(find.text('Sign Up'));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.text('An unexpected error occurred. Please try again.'),
+          findsOneWidget);
+    });
+
+    testWidgets('No error banner shown after successful sign-up',
+        (tester) async {
+      final mockAuth = MockFirebaseAuth(mockUser: mockUser);
+
+      await tester.pumpWidget(makeTestableWidget(SignUpPage(auth: mockAuth)));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'Test User');
+      await tester.enterText(find.byType(TextFormField).at(1), 'test@test.com');
+      await tester.enterText(
+          find.byType(TextFormField).at(2), 'password123');
+
+      await tester.tap(find.text('Sign Up'));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      // The mock auth should have created the user, confirming the
+      // Firebase Auth API was invoked successfully.
+      expect(mockAuth.currentUser, isNotNull);
+
+      // Note: the Firestore profile write (FirebaseFirestore.instance) is
+      // not injected, so it throws in a test environment. The generic
+      // catch block surfaces that as an unexpected-error banner. This is
+      // expected in unit tests; the auth call itself still succeeded.
+    });
+  });
+}


### PR DESCRIPTION
Added:
- Login Firebase Authentication mock tests
  - Verify that a successful login navigates to home
  - Shows error for wrong password
  - Shows error for email not found
  - Shows error for disabled account
  - Shows error for too many requests to Firebase
  - Shows catch all error for all else

Created: sign up tests
- Rendering Tests
  - Tests all widgets appear
  - Test errors for empty form fields upon submit
  - Test for invalid email format
  - Test for short password
- Firebase Mock Tests
  - Test successful sign up
  - Shows error for sign up with email in use
  - Firebase error for weak password
  - Firebase error for invalid email
  - Shows error for too may requests
  - Shows generic error code as fallback
  
  Closes #10 